### PR TITLE
add intelligent container name sorting

### DIFF
--- a/ui/src/lib/containerNames.test.ts
+++ b/ui/src/lib/containerNames.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseNumberInput, buildContainerNames } from './containerNames';
+import { parseNumberInput, buildContainerNames, parseContainerName, sortContainerNames } from './containerNames';
 
 describe('parseNumberInput', () => {
     it('should parse a single number', () => {
@@ -85,5 +85,66 @@ describe('buildContainerNames', () => {
         expect(buildContainerNames('', 'containers')).toEqual([]);
         expect(buildContainerNames('', 'bowls')).toEqual([]);
         expect(buildContainerNames('', 'jars')).toEqual([]);
+    });
+});
+
+describe('parseContainerName', () => {
+    it('should parse underscore-separated names', () => {
+        expect(parseContainerName('bowl_5')).toEqual({ type: 'bowl', number: 5 });
+        expect(parseContainerName('jar_10')).toEqual({ type: 'jar', number: 10 });
+    });
+
+    it('should parse hyphen-separated names', () => {
+        expect(parseContainerName('u-3')).toEqual({ type: 'u', number: 3 });
+        expect(parseContainerName('box-42')).toEqual({ type: 'box', number: 42 });
+    });
+
+    it('should parse plain numbers', () => {
+        expect(parseContainerName('42')).toEqual({ type: '', number: 42 });
+        expect(parseContainerName('1')).toEqual({ type: '', number: 1 });
+    });
+
+    it('should handle names without separator', () => {
+        expect(parseContainerName('bowl5')).toEqual({ type: 'bowl', number: 5 });
+    });
+
+    it('should fallback for unrecognized formats', () => {
+        expect(parseContainerName('abc')).toEqual({ type: 'abc', number: 0 });
+    });
+});
+
+describe('sortContainerNames', () => {
+    it('should sort numerically within same type', () => {
+        expect(sortContainerNames(['bowl_10', 'bowl_2', 'bowl_1'])).toEqual(['bowl_1', 'bowl_2', 'bowl_10']);
+    });
+
+    it('should sort alphabetically by type first', () => {
+        expect(sortContainerNames(['jar_1', 'bowl_1', 'u-1'])).toEqual(['bowl_1', 'jar_1', 'u-1']);
+    });
+
+    it('should handle mixed types and numbers', () => {
+        expect(sortContainerNames(['jar_5', 'bowl_3', 'jar_2', 'bowl_10'])).toEqual(['bowl_3', 'bowl_10', 'jar_2', 'jar_5']);
+    });
+
+    it('should handle plain numbers (no type prefix)', () => {
+        expect(sortContainerNames(['10', '2', '1'])).toEqual(['1', '2', '10']);
+    });
+
+    it('should sort plain numbers before prefixed containers', () => {
+        expect(sortContainerNames(['bowl_1', '5', '2'])).toEqual(['2', '5', 'bowl_1']);
+    });
+
+    it('should handle empty array', () => {
+        expect(sortContainerNames([])).toEqual([]);
+    });
+
+    it('should not mutate original array', () => {
+        const original = ['bowl_10', 'bowl_2', 'bowl_1'];
+        sortContainerNames(original);
+        expect(original).toEqual(['bowl_10', 'bowl_2', 'bowl_1']);
+    });
+
+    it('should handle u- prefix containers', () => {
+        expect(sortContainerNames(['u-10', 'u-2', 'u-1'])).toEqual(['u-1', 'u-2', 'u-10']);
     });
 });

--- a/ui/src/lib/containerNames.ts
+++ b/ui/src/lib/containerNames.ts
@@ -49,3 +49,43 @@ export function buildContainerNames(input: string, containerType: ContainerType)
             return numbers.map(n => `jar_${n}`);
     }
 }
+
+/**
+ * Parses a container name into its type and number parts.
+ * Container names can be separated by hyphen or underscore.
+ * Examples: "bowl_5" -> { type: "bowl", number: 5 }
+ *           "u-3" -> { type: "u", number: 3 }
+ *           "42" -> { type: "", number: 42 }
+ */
+export function parseContainerName(name: string): { type: string; number: number } {
+    const match = name.match(/^([a-zA-Z]*)[-_]?(\d+)$/);
+    if (match) {
+        return {
+            type: match[1] || "",
+            number: parseInt(match[2], 10)
+        };
+    }
+    // Fallback: treat entire name as type with no number
+    return { type: name, number: 0 };
+}
+
+/**
+ * Sorts container names intelligently:
+ * - First alphabetically by container type (e.g., "bowl", "jar", "u")
+ * - Then numerically by container number
+ */
+export function sortContainerNames(containers: string[]): string[] {
+    return [...containers].sort((a, b) => {
+        const parsedA = parseContainerName(a);
+        const parsedB = parseContainerName(b);
+
+        // First compare by type alphabetically
+        const typeCompare = parsedA.type.localeCompare(parsedB.type);
+        if (typeCompare !== 0) {
+            return typeCompare;
+        }
+
+        // Then compare by number numerically
+        return parsedA.number - parsedB.number;
+    });
+}

--- a/ui/src/routes/Item.svelte
+++ b/ui/src/routes/Item.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { appState } from "$lib/stores";
+    import { sortContainerNames } from "$lib/containerNames";
 
     let { item, freezerName }: { item: any; freezerName: string } = $props();
 
@@ -56,7 +57,7 @@
 
 <div class="flex gap-2">
     <span>{item.Name} ({item.Date})</span>
-    {#each item.Containers.sort() as container}
+    {#each sortContainerNames(item.Containers) as container}
         <button onclick={() => openDialog(container)}
                 class="px-2 border border-grey-500 rounded">{container}</button>
     {/each}


### PR DESCRIPTION
Container names are now sorted by type alphabetically, then by number numerically. For example, "bowl_10, bowl_2, jar_1" becomes "bowl_2, bowl_10, jar_1".

The prompt to Claude for this change was:
> Modify Item.svelte to sort item.Containers more intelligently. Split the container name into two parts: a container type, and a container number (separated by a hyphen or underscore). First sort container names alphabetically based on the container type, and then sort *numerically* based on the container number