### PR TITLE
Use Item component in all views for move/remove functionality

### DIFF
--- a/ui/src/routes/GroupByContents.svelte
+++ b/ui/src/routes/GroupByContents.svelte
@@ -1,42 +1,42 @@
 <script lang="ts">
-    import { appState } from "$lib/stores";
-    import { sortContainerNames } from "$lib/containerNames";
+    import { appState, type FreezerItem } from "$lib/stores";
+    import Item from "./Item.svelte";
 
-    interface ItemWithLocation {
-        container: string;
+    interface ItemByFreezer {
+        item: FreezerItem;
         freezerName: string;
     }
 
-    interface GroupedItem {
+    interface GroupedByName {
         name: string;
-        containers: ItemWithLocation[];
+        itemsByFreezer: ItemByFreezer[];
     }
 
     const groupedByContents = $derived.by(() => {
         if (!$appState) return [];
 
-        const itemMap = new Map<string, ItemWithLocation[]>();
+        // Group by item name, then by freezer
+        const nameMap = new Map<string, Map<string, FreezerItem>>();
 
         for (const freezer of $appState.Freezers) {
             for (const item of freezer.Contents) {
-                const existing = itemMap.get(item.Name) || [];
-                for (const container of item.Containers) {
-                    existing.push({
-                        container,
-                        freezerName: freezer.Name
-                    });
+                if (!nameMap.has(item.Name)) {
+                    nameMap.set(item.Name, new Map());
                 }
-                itemMap.set(item.Name, existing);
+                const freezerMap = nameMap.get(item.Name)!;
+                freezerMap.set(freezer.Name, item);
             }
         }
 
-        const result: GroupedItem[] = [];
-        for (const [name, containers] of itemMap) {
-            const sortedContainers = containers.sort((a, b) => {
-                const sorted = sortContainerNames([a.container, b.container]);
-                return sorted[0] === a.container ? -1 : 1;
-            });
-            result.push({ name, containers: sortedContainers });
+        const result: GroupedByName[] = [];
+        for (const [name, freezerMap] of nameMap) {
+            const itemsByFreezer: ItemByFreezer[] = [];
+            for (const [freezerName, item] of freezerMap) {
+                itemsByFreezer.push({ item, freezerName });
+            }
+            // Sort by freezer name for consistent ordering
+            itemsByFreezer.sort((a, b) => a.freezerName.localeCompare(b.freezerName));
+            result.push({ name, itemsByFreezer });
         }
 
         return result.sort((a, b) => a.name.localeCompare(b.name));
@@ -47,11 +47,12 @@
     {#each groupedByContents as group}
         <div class="flex flex-col gap-1">
             <h2 class="font-bold">{group.name}</h2>
-            <ul class="list-disc pl-6">
-                {#each group.containers as item}
-                    <li>{item.container} <span class="text-gray-500">({item.freezerName})</span></li>
-                {/each}
-            </ul>
+            {#each group.itemsByFreezer as entry}
+                <div class="pl-4 flex items-center gap-2">
+                    <span class="text-gray-500">({entry.freezerName})</span>
+                    <Item item={entry.item} freezerName={entry.freezerName} />
+                </div>
+            {/each}
         </div>
     {/each}
 </div>

--- a/ui/src/routes/GroupByDate.svelte
+++ b/ui/src/routes/GroupByDate.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-    import { appState } from "$lib/stores";
-    import { sortContainerNames } from "$lib/containerNames";
+    import { appState, type FreezerItem } from "$lib/stores";
+    import Item from "./Item.svelte";
 
     interface ItemWithLocation {
-        name: string;
-        date: string;
-        containers: string[];
+        item: FreezerItem;
         freezerName: string;
     }
 
@@ -17,28 +15,22 @@
         for (const freezer of $appState.Freezers) {
             for (const item of freezer.Contents) {
                 items.push({
-                    name: item.Name,
-                    date: item.Date,
-                    containers: sortContainerNames(item.Containers),
+                    item,
                     freezerName: freezer.Name
                 });
             }
         }
 
         // Sort by date ascending (oldest first)
-        return items.sort((a, b) => a.date.localeCompare(b.date));
+        return items.sort((a, b) => a.item.Date.localeCompare(b.item.Date));
     });
 </script>
 
 <div class="flex flex-col gap-4">
-    {#each sortedByDate as item}
+    {#each sortedByDate as entry}
         <div class="flex flex-col gap-1">
-            <h2 class="font-bold">{item.date}: {item.name}</h2>
-            <ul class="list-disc pl-6">
-                {#each item.containers as container}
-                    <li>{container} <span class="text-gray-500">({item.freezerName})</span></li>
-                {/each}
-            </ul>
+            <span class="text-gray-500">({entry.freezerName})</span>
+            <Item item={entry.item} freezerName={entry.freezerName} />
         </div>
     {/each}
 </div>

--- a/ui/src/routes/GroupByNumber.svelte
+++ b/ui/src/routes/GroupByNumber.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-    import { appState } from "$lib/stores";
+    import { appState, type FreezerItem } from "$lib/stores";
     import { parseContainerName } from "$lib/containerNames";
+    import Item from "./Item.svelte";
 
     interface ContainerInfo {
         name: string;
         number: number;
-        itemName: string;
+        item: FreezerItem;  // Synthetic item with just this container
         freezerName: string;
     }
 
@@ -33,10 +34,15 @@
                 for (const container of item.Containers) {
                     const parsed = parseContainerName(container);
                     const existing = typeMap.get(parsed.type) || [];
+                    // Create a synthetic FreezerItem with just this single container
                     existing.push({
                         name: container,
                         number: parsed.number,
-                        itemName: item.Name,
+                        item: {
+                            Name: item.Name,
+                            Date: item.Date,
+                            Containers: [container]
+                        },
                         freezerName: freezer.Name
                     });
                     typeMap.set(parsed.type, existing);
@@ -84,7 +90,8 @@
             <ol class="list-decimal pl-6">
                 {#each group.containers as container}
                     <li value={container.number}>
-                        {container.name}: {container.itemName} <span class="text-gray-500">({container.freezerName})</span>
+                        <span class="text-gray-500">({container.freezerName})</span>
+                        <Item item={container.item} freezerName={container.freezerName} />
                     </li>
                 {/each}
             </ol>


### PR DESCRIPTION
All grouped views (Date, Contents, Label) now render items using the Item.svelte component instead of plain spans, enabling move and remove actions from any view.